### PR TITLE
[java17]: Upgrade pmd to 6.41.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <license.owner>SonarSource SA and others</license.owner>
     <license.mailto>mailto:jens AT gerdes DOT digital</license.mailto>
-    <pmd.version>6.31.0</pmd.version>
+    <pmd.version>6.41.0</pmd.version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <mockito.version>3.8.0</mockito.version>
     <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
Upgrades PMD engine: 
Be able to pass Java17 code.
Tested in our Sonarqube instance (9.1.0.47736) and works as expected:
* Java 17 code passed the scanner
* If the code has any PMD issue it is reported correctly