### PR TITLE
fix xpath error

### DIFF
--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/xml/factory/ActiveRulesRuleSetFactory.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/xml/factory/ActiveRulesRuleSetFactory.java
@@ -58,7 +58,7 @@ public class ActiveRulesRuleSetFactory implements RuleSetFactory {
             addRuleProperties(rule, pmdRule);
             ruleset.addRule(pmdRule);
 
-            pmdRule.processXpath(rule.internalKey());
+            pmdRule.processXpath(rule.ruleKey().rule());
         }
         return ruleset;
     }


### PR DESCRIPTION
xpath rule doesn't work
because the name set to className（rule.internalKey）
can't match activeRule