### PR TITLE
Replaced deprecated valueOfString method with valueOf

### DIFF
--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/xml/factory/ActiveRulesRuleSetFactory.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/xml/factory/ActiveRulesRuleSetFactory.java
@@ -54,7 +54,7 @@ public class ActiveRulesRuleSetFactory implements RuleSetFactory {
         ruleset.setDescription(String.format("Sonar Profile: %s", repositoryKey));
         for (ActiveRule rule : rules) {
             String configKey = rule.internalKey();
-            PmdRule pmdRule = new PmdRule(configKey, PmdLevelUtils.toLevel(RulePriority.valueOfString(rule.severity())));
+            PmdRule pmdRule = new PmdRule(configKey, PmdLevelUtils.toLevel(RulePriority.valueOf(rule.severity())));
             addRuleProperties(rule, pmdRule);
             ruleset.addRule(pmdRule);
 


### PR DESCRIPTION
Sonar removed deprecated methods in version 10.0. One of them is the `valueOfString` method of the `RulePriority` enum.

This PR fixes issue #413 