### PR TITLE
fix: set maven.compiler.release to 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,7 @@
     <sonar-ws-client.version>5.1</sonar-ws-client.version>
     <!-- Technical settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <!-- Maven plugin versions -->
     <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
     <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>


### PR DESCRIPTION
Cross-compiling to Java 8 class files improves compatibilty