### PR TITLE
issue 543: revivify XPathRule via groovy xml rules generator

### DIFF
--- a/docs/pmd_release_notes_4.1.0.md
+++ b/docs/pmd_release_notes_4.1.0.md
@@ -3,11 +3,11 @@ _Do not edit this generated file._
 
 ## Summary
 - Total rules in old version (4.0.3): 206
-- Total rules in new version (4.1.0): 281
+- Total rules in new version (4.1.0): 282
 - Rules added: 80
-- Rules removed: 5
+- Rules removed: 4
 - Rules unchanged: 46
-- Rules updated: 154
+- Rules updated: 155
 - Rules renamed: 11
 
 ## Added Rules
@@ -255,6 +255,7 @@ The following rules have been updated in the new version:
 | UselessOverridingMethod | Useless overriding method |  | Medium | Deprecated | Active | [java:S1185](https://rules.sonarsource.com/java/RSPEC-1185) | design |
 | UselessParentheses | Useless parentheses | Info | Low | Deprecated | Active | [java:S1110](https://rules.sonarsource.com/java/RSPEC-1110) | codestyle |
 | UselessStringValueOf | Useless string value of | Low | Medium | Deprecated | Active | [java:S1153](https://rules.sonarsource.com/java/RSPEC-1153) | performance |
+| XPathRule | XPath rule | Medium |  | Deprecated | Active |  |  |
 
 ## Unchanged Rules
 The following rules exist in both versions with no changes:
@@ -334,6 +335,5 @@ The following rules have been removed in the new version:
 | CloneMethodMustImplementCloneableWithTypeResolution | Medium | Deprecated | errorprone |
 | LooseCouplingWithTypeResolution | Medium | Deprecated | bestpractices |
 | UnnecessaryParentheses | Low | Deprecated | codestyle |
-| XPathRule | Medium | Deprecated |  |
 
-Report generated on Tue Jul 15 17:33:57 CEST 2025
+Report generated on Wed Jul 16 16:21:38 CEST 2025

--- a/scripts/pmd7_rules_xml_generator.groovy
+++ b/scripts/pmd7_rules_xml_generator.groovy
@@ -1128,7 +1128,7 @@ def formatDescription = { ruleData, language ->
             }
             // Ensure the code example is properly formatted with proper line breaks
             // and no paragraph tags inside code blocks
-            markdownContent.append("```java\n")
+            markdownContent.append("```${language.toLowerCase()}\n")
             markdownContent.append(example)
             markdownContent.append("\n```\n\n")
         }
@@ -1336,6 +1336,78 @@ println ""
 println "Generating Kotlin rules XML file..."
 println "=" * 30
 def kotlinSuccess = generateXmlFile(kotlinOutputFilePath, kotlinRules, "Kotlin")
+
+// Add XPathRule as a special case to the Java rules XML file
+println ""
+println "Adding XPathRule to Java rules XML file..."
+println "=" * 30
+
+try {
+    // Read the existing XML file
+    def xmlFile = javaOutputFilePath
+    def xmlContent = xmlFile.text
+
+    // Check if XPathRule already exists
+    if (xmlContent.contains("<key>XPathRule</key>")) {
+        println "XPathRule already exists in the Java rules XML file."
+    } else {
+        // Find the closing </rules> tag
+        def closingTagIndex = xmlContent.lastIndexOf("</rules>")
+        if (closingTagIndex != -1) {
+            // Insert the XPathRule before the closing tag
+            def xpathRuleXml = """  <rule>
+    <key>XPathRule</key>
+    <name>PMD XPath Template Rule</name>
+    <priority>MAJOR</priority>
+    <configKey>net.sourceforge.pmd.lang.rule.xpath.XPathRule</configKey>
+    <cardinality>MULTIPLE</cardinality>
+    <param key="xpath" type="TEXT">
+      <defaultValue></defaultValue>
+      <description>The PMD 7 compatible XPath expression for Java.</description>
+    </param>
+    <param key="message" type="STRING">
+      <defaultValue></defaultValue>
+      <description>The message for issues created by this rule.</description>
+    </param>
+    <description><![CDATA[<p>PMD provides a very handy method for creating new rules by writing an XPath query. When the XPath query finds a match, a violation is created.</p>
+<p>Let's take a simple example: assume we have a Factory class that must be always declared final.
+We'd like to report a violation each time a declaration of Factory is not declared final. Consider the following class:</p>
+<pre><code class="language-java">
+import io.factories.Factory;
+
+public class a {
+  Factory f1;
+
+  void myMethod() {
+    Factory f2;
+    int a;
+  }
+}
+</code></pre>
+<p>The following expression does the magic we need:</p>
+<pre><code class="language-xpath">
+//(FieldDeclaration|LocalVariableDeclaration)[
+      not (pmd-java:modifiers() = 'final')
+   ]/ClassType[pmd-java:typeIs('io.factories.Factory')]
+</code></pre>
+<p>See the <a href="https://docs.pmd-code.org/latest/pmd_userdocs_extending_writing_xpath_rules.html" target="_blank">XPath rule tutorial</a> for more information.</p>
+<p>Tip: use the PMD Designer application to create the XPath expressions.</p>
+]]></description>
+    <tag>pmd</tag>
+    <tag>xpath</tag>
+  </rule>
+"""
+            def newXmlContent = xmlContent.substring(0, closingTagIndex) + xpathRuleXml + xmlContent.substring(closingTagIndex)
+            xmlFile.text = newXmlContent
+            println "Successfully added XPathRule to Java rules XML file."
+        } else {
+            println "ERROR: Could not find closing </rules> tag in Java rules XML file."
+        }
+    }
+} catch (Exception e) {
+    println "ERROR adding XPathRule to Java rules XML file: ${e.message}"
+    e.printStackTrace()
+}
 
 println ""
 if (javaSuccess && kotlinSuccess) {

--- a/scripts/pmd7_rules_xml_generator.groovy
+++ b/scripts/pmd7_rules_xml_generator.groovy
@@ -1375,7 +1375,7 @@ We'd like to report a violation each time a declaration of Factory is not declar
 <pre><code class="language-java">
 import io.factories.Factory;
 
-public class a {
+public class Foo {
   Factory f1;
 
   void myMethod() {

--- a/sonar-pmd-plugin/src/main/resources/org/sonar/plugins/pmd/rules-java.xml
+++ b/sonar-pmd-plugin/src/main/resources/org/sonar/plugins/pmd/rules-java.xml
@@ -7538,4 +7538,45 @@ a block <code>{}</code> is sufficient.</p>
     <tag>pmd</tag>
     <tag>bestpractices</tag>
   </rule>
+  <rule>
+    <key>XPathRule</key>
+    <name>PMD XPath Template Rule</name>
+    <priority>MAJOR</priority>
+    <configKey>net.sourceforge.pmd.lang.rule.xpath.XPathRule</configKey>
+    <cardinality>MULTIPLE</cardinality>
+    <param key="xpath" type="TEXT">
+      <defaultValue></defaultValue>
+      <description>The PMD 7 compatible XPath expression for Java.</description>
+    </param>
+    <param key="message" type="STRING">
+      <defaultValue></defaultValue>
+      <description>The message for issues created by this rule.</description>
+    </param>
+    <description><![CDATA[<p>PMD provides a very handy method for creating new rules by writing an XPath query. When the XPath query finds a match, a violation is created.</p>
+<p>Let's take a simple example: assume we have a Factory class that must be always declared final.
+We'd like to report a violation each time a declaration of Factory is not declared final. Consider the following class:</p>
+<pre><code class="language-java">
+import io.factories.Factory;
+
+public class a {
+  Factory f1;
+
+  void myMethod() {
+    Factory f2;
+    int a;
+  }
+}
+</code></pre>
+<p>The following expression does the magic we need:</p>
+<pre><code class="language-xpath">
+//(FieldDeclaration|LocalVariableDeclaration)[
+      not (pmd-java:modifiers() = 'final')
+   ]/ClassType[pmd-java:typeIs('io.factories.Factory')]
+</code></pre>
+<p>See the <a href="https://docs.pmd-code.org/latest/pmd_userdocs_extending_writing_xpath_rules.html" target="_blank">XPath rule tutorial</a> for more information.</p>
+<p>Tip: use the PMD Designer application to create the XPath expressions.</p>
+]]></description>
+    <tag>pmd</tag>
+    <tag>xpath</tag>
+  </rule>
 </rules>

--- a/sonar-pmd-plugin/src/main/resources/org/sonar/plugins/pmd/rules-kotlin.xml
+++ b/sonar-pmd-plugin/src/main/resources/org/sonar/plugins/pmd/rules-kotlin.xml
@@ -8,7 +8,7 @@
     <description><![CDATA[<h2>Title of issues: Function names should have non-cryptic and clear names.</h2>
 <p>Function names should be easy to understand and describe the intention. Makes developers happy.</p>
 <h2>Example</h2>
-<p><pre><code class="language-java"> fun cl() {} // violation, no unavailable attribute added to the function declaration
+<p><pre><code class="language-kotlin"> fun cl() {} // violation, no unavailable attribute added to the function declaration
  
  fun calculateLayout() // no violation</code></pre></p>
 <p><a href="https://docs.pmd-code.org/pmd-doc-7.15.0/pmd_rules_kotlin_bestpractices.html#functionnametooshort">Full documentation</a></p>]]></description>
@@ -23,7 +23,7 @@
     <description><![CDATA[<h2>Title of issues: Ensure you override both equals() and hashCode()</h2>
 <p>Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.</p>
 <h2>Example</h2>
-<p><pre><code class="language-java"> class Bar {        // poor, missing a hashCode() method
+<p><pre><code class="language-kotlin"> class Bar {        // poor, missing a hashCode() method
      override fun equals(o: Any?): Boolean {
        // do some comparison
      }

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdRulesDefinitionTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdRulesDefinitionTest.java
@@ -43,7 +43,7 @@ class PmdRulesDefinitionTest {
 
         List<Rule> rules = repository.rules();
 
-        assertThat(rules).hasSize(281);
+        assertThat(rules).hasSize(282);
 
         for (Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
 example updated for XPath PMD7
 
 Name is now: PMD XPath Template Rule
 
 Known issue: the html code highliting in SonarQube does not switch to xpath, so // is considered comment and written out in cursive gray font...
 
 fixes #543 